### PR TITLE
Added support for arrays of commands in a hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-scripts",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Add scripting capabilities to the Serverless Framework",
   "keywords": [
     "serverless",

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,12 @@ class Scripts {
   runHook(name) {
     const hooks = this.getConfig().hooks;
     const hook = hooks[name];
-    this.execute(hook);
+    if (Array.isArray(hook)) {
+      hook.forEach((h) => this.execute(h));
+    } else {
+      this.execute(hook);
+    }
+    
   }
 
   execute(command) {


### PR DESCRIPTION
I added the ability to add an array of commands to a hook:

```
hooks:
  deploy:deploy:
    - node bin/doSomething.js
    - node bin/doSomethingElse.js
    - echo Finished deploying ${self:service} service!
```