### PR TITLE
Include serverless environment variables in script environment.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,12 @@ class Scripts {
   }
 
   execute(command) {
-    execSync(command, { stdio: 'inherit' });
+    const providerEnvVars =
+          this.serverless.service &&
+          this.serverless.service.provider &&
+          this.serverless.service.provider.environment || {};
+    const envVars = Object.assign({}, process.env, providerEnvVars);
+    execSync(command, { stdio: 'inherit', env: envVars });
   }
 }
 


### PR DESCRIPTION
In the current release of `serverless-plugin-scripts`, environment variables defined in `serverless.yml` do not propagate to the script. This patch modifies the invocation of `execSync` to include those environment variables.